### PR TITLE
Fixed output justification

### DIFF
--- a/lib/pod/command/plugins_helper.rb
+++ b/lib/pod/command/plugins_helper.rb
@@ -86,9 +86,10 @@ module Pod
 
         UI.title(plugin_colored_name, '', 1) do
           UI.puts_indented plugin['description']
-          UI.labeled('Gem', plugin['gem'])
-          UI.labeled('URL',   plugin['url'])
-          UI.labeled('Author', plugin['author']) if verbose
+          ljust = verbose ? 14 : 11
+          UI.labeled('Gem', plugin['gem'], ljust)
+          UI.labeled('URL',   plugin['url'], ljust)
+          UI.labeled('Author', plugin['author'], ljust) if verbose
         end
       end
 


### PR DESCRIPTION
Now that `UI.labeled` accepts an optional 3rd parameter to specify the `ljust` (see CocoaPods/CocoaPods@c0300905acb3a84baa8bded839be1ccef6553921) we can use it in here to adjust the alignment of the output.

---

I didn't commit this code directly to the master because **I'm wondering if there is anything special to do before commiting a code in one repo (cocoapods-plugins) than depends on a commit on another repo (CocoaPods)**. What if one were to test the master of cocoapods-plugins, with this fix using `UI.labeled` with 3 parameters, without having the up-to-date master of the CocoaPods repo?

_Should we wait for CocoaPods to release a patch version then make the Gemfile of cocoapods-plugins depend on this minimum version of the CocoaPods gem? Or doesn't it matter? Or does "bundle install" take care of everything so that we are ensured that the CocoaPods gem is up-to-date and pointing to the master/HEAD?_
