### PR TITLE
Issues/16 print out gem versions on a --verbose

### DIFF
--- a/lib/pod/command/gem_helper.rb
+++ b/lib/pod/command/gem_helper.rb
@@ -1,0 +1,118 @@
+require 'pod/command/gem_index_cache'
+
+module Pod
+  class Command
+    # This module is used by Command::PluginsHelper to download the Gem
+    # Specification data, check if a Gem is installed, and provide info
+    # on all versions of a Gem.
+    #
+    module GemHelper
+      # A GemIndexCache to manage downloading/caching the spec index.
+      #
+      @cache = nil
+
+      # Getter for GemIndexCache
+      #
+      # @return [GemIndexCache] a new or memoized GemIndexCache
+      #
+      def self.cache
+        @cache ||= GemIndexCache.new
+      end
+
+      # Instantiate a cache and download the spec index if it has
+      # not already been done.
+      #
+      def self.download_and_cache_specs
+        cache.download_and_cache_specs
+      end
+
+      # Tells if a gem is installed
+      #
+      # @param [String] gem_name
+      #        The name of the plugin gem to test
+      #
+      # @param [String] version_string
+      #        An optional version string, used to check if a specific
+      #        version of a gem is installed
+      #
+      # @return [Bool] true if the gem is installed, false otherwise.
+      #
+      def self.gem_installed?(gem_name, version_string = nil)
+        version = Gem::Version.new(version_string) if version_string
+
+        gems = Gem::Specification.find_all_by_name(gem_name)
+        return !gems.empty? unless version
+
+        gems.each do |gem|
+          return true if gem.version == version
+        end
+
+        false
+      end
+
+      # Get the version of a gem that is installed locally. If more than
+      # one version is installed, this returns the first version found,
+      # which MAY not be the highest/newest version.
+      #
+      # @return [String] The version of the gem that is installed,
+      #                  or nil if it is not installed.
+      #
+      def self.installed_version(gem_name)
+        gem = Gem::Specification.find_all_by_name(gem_name).first
+        gem ? gem.version.to_s : nil
+      end
+
+      # Create a string containing all versions of a plugin,
+      # colored to indicate if a specific version is installed
+      # locally.
+      #
+      # @param [String] plugin_name
+      #        The name of the plugin gem
+      #
+      # @param [GemIndexCache] index_cache
+      #        Optional index cache can be passed in, otherwise
+      #        the module instance is used.
+      #
+      # @return [String] a string containing a comma separated
+      #                  concatenation of all versions of a plugin
+      #                  that were found on rubygems.org
+      #
+      def self.versions_string(plugin_name, index_cache = @cache)
+        name_tuples = index_cache.specs_with_name(plugin_name)
+
+        sorted_versions = name_tuples.sort_by do |name_tuple|
+          name_tuple.version
+        end
+
+        version_strings = colorize_versions(sorted_versions)
+        version_strings.join ', '
+      end
+
+      #----------------#
+
+      private
+
+      # Colorize an Array of version strings so versions that are installed
+      # are green and uninstalled versions are yellow.
+      #
+      # @param [Array] versions
+      #        sorted array of Gem::NameTuples representing all versions of
+      #        a plugin gem.
+      #
+      # @return [Array] An array of strings, each one being the version
+      #                 string of the same plugin
+      #
+      def self.colorize_versions(versions)
+        colored_strings = []
+        versions.reverse_each do |name_tuple|
+          if gem_installed?(name_tuple.name, name_tuple.version.to_s)
+            colored_strings << name_tuple.version.to_s.green
+          else
+            colored_strings << name_tuple.version.to_s.yellow
+          end
+        end
+        colored_strings
+      end
+    end
+  end
+end

--- a/lib/pod/command/gem_index_cache.rb
+++ b/lib/pod/command/gem_index_cache.rb
@@ -1,0 +1,87 @@
+require 'pod/command/gem_helper'
+
+module Pod
+  class Command
+    # This class is used by Command::GemsHelper to download the Gem
+    # Specification index from rubygems.org and provide info about
+    # the index.
+    #
+    class GemIndexCache
+      # A memoized hash of all the rubygem specs. If it is nil, the specs will
+      # be downloaded, which will take a few seconds to download.
+      #
+      # @return [Hash] The hash of all rubygems
+      #
+      def specs
+        @specs ||= download_specs
+      end
+
+      # Alias to make the initial caching process more readable.
+      #
+      alias_method :download_and_cache_specs, :specs
+
+      # Get an Array of Gem::NameTuple objects that match a given
+      # spec name.
+      #
+      # @param [String] name
+      #        The name of the gem to match on (e.g. 'cocoapods-try')
+      #
+      # @return [Array] Array of Gem::NameTuple that match the name
+      #
+      def specs_with_name(name)
+        matching_specs = @specs.select do |spec|
+          spec[0].name == name
+        end
+
+        name_tuples = []
+        matching_specs.each do |(name_tuple, _)|
+          name_tuples << name_tuple
+        end
+
+        name_tuples
+      end
+
+      #----------------#
+
+      private
+
+      # Force the rubygem spec index file
+      #
+      # @return [Hash] The hash of all rubygems
+      #
+      def download_specs
+        UI.puts 'Downloading Rubygem specification index...'
+        fetcher = Gem::SpecFetcher.fetcher
+        results, errors = fetcher.available_specs(:released)
+
+        unless errors.empty?
+          UI.puts 'Error downloading Rubygem specification index: ' +
+                  errors.first.error.to_s
+          return []
+        end
+
+        flatten_fetcher_results(results)
+      end
+
+      # Flatten the dictionary returned from Gem::SpecFetcher
+      # to a simple array.
+      #
+      # @param [Hash] results
+      #        the hash returned from the call to
+      #        Gem::SpecFetcher.available_specs()
+      #
+      # @return [Array] Array of all spec results
+      #
+      def flatten_fetcher_results(results)
+        specs = []
+        results.each do |source, source_specs|
+          source_specs.each do |tuple|
+            specs << [tuple, source]
+          end
+        end
+
+        specs
+      end
+    end
+  end
+end

--- a/lib/pod/command/plugins/list.rb
+++ b/lib/pod/command/plugins/list.rb
@@ -1,4 +1,5 @@
 require 'pod/command/plugins_helper'
+require 'pod/command/gem_helper'
 
 module Pod
   class Command
@@ -18,6 +19,7 @@ module Pod
 
         def run
           plugins = PluginsHelper.known_plugins
+          GemHelper.download_and_cache_specs if self.verbose?
 
           UI.title 'Available CocoaPods Plugins:' do
             plugins.each do |plugin|

--- a/lib/pod/command/plugins/search.rb
+++ b/lib/pod/command/plugins/search.rb
@@ -1,4 +1,5 @@
 require 'pod/command/plugins_helper'
+require 'pod/command/gem_helper'
 
 module Pod
   class Command
@@ -44,6 +45,7 @@ module Pod
 
         def run
           plugins = PluginsHelper.matching_plugins(@query, @full_text_search)
+          GemHelper.download_and_cache_specs if self.verbose?
 
           UI.title "Available CocoaPods Plugins matching '#{@query}':"
           plugins.each do |plugin|

--- a/spec/command/gem_helper_spec.rb
+++ b/spec/command/gem_helper_spec.rb
@@ -1,0 +1,40 @@
+require File.expand_path('../spec_helper', File.dirname(__FILE__))
+
+# The CocoaPods namespace
+#
+module Pod
+  describe Command::GemHelper do
+    before do
+      UI.output = ''
+    end
+
+    after do
+      mocha_teardown
+    end
+
+    it 'detects if a gem is installed' do
+      Command::GemHelper.gem_installed?('bacon').should.be.true
+      Command::GemHelper.gem_installed?('fake-fake-fake-gem').should.be.false
+    end
+
+    it 'detects if a specific version of a gem is installed' do
+      Command::GemHelper.gem_installed?('bacon', Bacon::VERSION).should.be.true
+      impossibacon = Gem::Version.new(Bacon::VERSION).bump
+      Command::GemHelper.gem_installed?('bacon', impossibacon).should.be.false
+    end
+
+    it 'creates a version list that includes all versions of a single gem' do
+      spec2 = Gem::NameTuple.new('cocoapods-plugins', Gem::Version.new('0.2.0'))
+      spec1 = Gem::NameTuple.new('cocoapods-plugins', Gem::Version.new('0.1.0'))
+      response = [{ 1 => [spec2, spec1] }, []]
+      Gem::SpecFetcher.any_instance.stubs(:available_specs).returns(response)
+
+      @cache = Command::GemIndexCache.new
+      @cache.download_and_cache_specs
+      versions_string =
+        Command::GemHelper.versions_string('cocoapods-plugins', @cache)
+      versions_string.should.include('0.2.0')
+      versions_string.should.include('0.1.0')
+    end
+  end
+end

--- a/spec/command/gem_index_cache_spec.rb
+++ b/spec/command/gem_index_cache_spec.rb
@@ -1,0 +1,39 @@
+require File.expand_path('../spec_helper', File.dirname(__FILE__))
+
+# The CocoaPods namespace
+#
+module Pod
+  describe Command::GemIndexCache do
+
+    before do
+      @cache = Command::GemIndexCache.new
+      UI.output = ''
+    end
+
+    after do
+      mocha_teardown
+    end
+
+    it 'notifies the user that it is downloading the spec index' do
+      response = [{}, []]
+      Gem::SpecFetcher.any_instance.stubs(:available_specs).returns(response)
+
+      @cache.download_and_cache_specs
+      UI.output.should.include('Downloading Rubygem specification index...')
+      UI.output.should.not.include('Error downloading Rubygem specification')
+    end
+
+    it 'notifies the user when getting the spec index fails' do
+      error = Gem::RemoteFetcher::UnknownHostError.new('no host', 'bad url')
+      wrapper_error = stub(:error => error)
+      response = [[], [wrapper_error]]
+      Gem::SpecFetcher.any_instance.stubs(:available_specs).returns(response)
+
+      @cache.download_and_cache_specs
+      @cache.specs.should.be.empty?
+      UI.output.should.include('Downloading Rubygem specification index...')
+      UI.output.should.include('Error downloading Rubygem specification')
+    end
+
+  end
+end

--- a/spec/command/plugins_helper_spec.rb
+++ b/spec/command/plugins_helper_spec.rb
@@ -30,10 +30,5 @@ module Pod
       end.message.should.match(expected_error)
     end
 
-    it 'detects if a gem is installed' do
-      Helper = Command::PluginsHelper
-      Helper.gem_installed?('bacon').should.be.true
-      Helper.gem_installed?('fake-fake-fake-gem').should.be.false
-    end
   end
 end


### PR DESCRIPTION
This prints out a list of versions for all gem based plugins.

It's a WIP because I wanted to verify the rubygems support for legacy ruby. This uses features introduced in the 1.8.0 / 2011-04-34 rubygems release.

![Screenshot](http://dl.dropboxusercontent.com/s/t7m25ihovb9q6uo/2014-05-30%20at%2012.18%20PM.png)
