### PR TITLE
[pod plugins installed] List registered hooks (if any)

### DIFF
--- a/.rubocop_cocoapods.yml
+++ b/.rubocop_cocoapods.yml
@@ -58,6 +58,11 @@ Next:
 Metrics/ClassLength:
   Enabled: false
 
+# Arbitrary max lengths for methods simply do not work and enabling this will
+# lead to a never ending stream of annoyance and changes.
+Metrics/MethodLength:
+  Enabled: false
+
 # No enforced convention here.
 Metrics/BlockNesting:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -12,28 +12,33 @@ CocoaPods plugin which shows info about available CocoaPods plugins or helps you
 
 ## Usage
 
-#####List plugins
+##### List installed plugins
 
-    $ pod plugins
+    $ pod plugins installed
 
-List all known plugins (according to the list hosted on github.com/CocoaPods/cocoapods-plugins)
+List all installed CocoaPods plugins with their respective version (and pre_install/post_insall hooks if any)
 
-#####Search plugins
+##### List known plugins
+
+    $ pod plugins list
+
+List all known CocoaPods plugins (according to the list hosted on `http://github.com/CocoaPods/cocoapods-plugins`)
+
+##### Search plugins
 
     $ pod plugins search QUERY
 
-Searches plugins whose name contains the given text (ignoring case). With --full, it searches by name but also by author and description.
+Search plugins whose name contains the given text (ignoring case). With --full, it searches by name but also by author and description.
 
-#####Create a new plugin
+##### Create a new plugin
 
     $ pod plugins create NAME [TEMPLATE_URL]
 
-Creates a scaffold for the development of a new plugin according to the CocoaPods best practices.
+Create a scaffold for the development of a new plugin according to the CocoaPods best practices.
 If a `TEMPLATE_URL`, pointing to a git repo containing a compatible template, is specified, it will be used in place of the default one.
 
 ## Get your plugin listed
 
-The list of plugins is in the cocoapods-plugins repository at [https://github.com/CocoaPods/cocoapods-plugins/blob/master/plugins.json](https://github.com/CocoaPods/cocoapods-plugins/blob/master/plugins.json).
+    $ pod plugins publish
 
-To have your plugin listed, submit a pull request that adds your plugin details.
-
+Create an issue in the `cocoapods-plugins` GitHub repository to ask for your plugin to be added to the official list (with the proper JSON fragment to be added to `plugins.json` so we just have to copy/paste it).

--- a/lib/pod/command/plugins/installed.rb
+++ b/lib/pod/command/plugins/installed.rb
@@ -68,7 +68,7 @@ module Pod
           end
         end
 
-        # List of registered hook for the given plugin (if any)
+        # List of registered hook(s) (if any) for the given plugin
         #
         # @return [Array<String>]
         #         List of hooks the given plugin did register for.

--- a/lib/pod/command/plugins/installed.rb
+++ b/lib/pod/command/plugins/installed.rb
@@ -72,10 +72,10 @@ module Pod
           end
         end
 
-        # List of registered hook(s) (if any) for the given plugin
+        # Names of the registered hook(s) (if any) for the given plugin
         #
         # @return [Array<String>]
-        #         List of hooks the given plugin did register for.
+        #         Names of the hooks the given plugin did register for.
         #
         def registered_hooks(plugin)
           registrations = Pod::HooksManager.registrations

--- a/lib/pod/command/plugins/installed.rb
+++ b/lib/pod/command/plugins/installed.rb
@@ -22,7 +22,7 @@ module Pod
           plugins = CLAide::Command::PluginManager.specifications
 
           UI.title 'Installed CocoaPods Plugins:' do
-            if self.verbose?
+            if verbose?
               print_verbose_list(plugins)
             else
               print_compact_list(plugins)
@@ -43,7 +43,11 @@ module Pod
           plugins.each do |plugin|
             name_just = plugin.name.ljust(max_length)
             hooks = registered_hooks(plugin)
-            hooks_list = hooks.empty? ? '' : " (#{hooks.join(' & ')} hook)"
+            hooks_list = ''
+            unless hooks.empty?
+              suffix = 'hook'.pluralize(hooks.count)
+              hooks_list = " (#{hooks.to_sentence} #{suffix})"
+            end
             UI.puts_indented " - #{name_just} : #{plugin.version}#{hooks_list}"
           end
         end

--- a/spec/command/plugins/installed_spec.rb
+++ b/spec/command/plugins/installed_spec.rb
@@ -1,0 +1,143 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+# The CocoaPods namespace
+#
+module Pod
+  describe Command::Plugins::Installed do
+    extend SpecHelper::PluginsStubs
+
+    def stub_plugins(plugins_and_hooks)
+      specs = []
+      registrations = {}
+      plugins_and_hooks.each do |(plugin_name, hooks)|
+        # Load Plugin GemSpec
+        fixture_path = fixture("#{plugin_name}.gemspec")
+        specs.push Gem::Specification.load(fixture_path.to_s)
+        # Fill hook registrations hash
+        Array(hooks).each do |hook_name|
+          registrations[hook_name] ||= []
+          hook = Pod::HooksManager::Hook.new(hook_name, plugin_name, {})
+          registrations[hook_name] << hook
+        end
+      end
+
+      Pod::HooksManager.stubs(:registrations).returns(registrations)
+      CLAide::Command::PluginManager.stubs(:specifications).returns(specs)
+    end
+
+    before do
+      UI.output = ''
+      Pod::HooksManager.registrations
+    end
+
+    it 'registers itself' do
+      Command.parse(%w(plugins installed)).
+        should.be.instance_of Command::Plugins::Installed
+    end
+
+    #--- Output printing
+
+    describe 'Compact List' do
+
+      before do
+        @command = Pod::Command::Plugins::Installed.new CLAide::ARGV.new([])
+      end
+
+      it 'no hooks' do
+        stub_plugins('cocoapods-foo1' => nil, 'cocoapods-foo2' => nil)
+
+        @command.run
+        UI.output.should.include('   - cocoapods-foo1 : 2.0.1')
+        UI.output.should.include('   - cocoapods-foo2 : 2.0.2')
+        UI.output.should.not.include('pre_install')
+        UI.output.should.not.include('post_install')
+      end
+
+      it 'one hook' do
+        stub_plugins(
+          'cocoapods-foo1' => :pre_install,
+          'cocoapods-foo2' => :post_install,
+        )
+
+        @command.run
+        UI.output.should.include('   - cocoapods-foo1 : 2.0.1 ' \
+          '(pre_install hook)')
+        UI.output.should.include('   - cocoapods-foo2 : 2.0.2 ' \
+          '(post_install hook)')
+      end
+
+      it 'two hooks' do
+        stub_plugins('cocoapods-foo1' => [:pre_install, :post_install])
+
+        @command.run
+        UI.output.should.include(' - cocoapods-foo1 : 2.0.1 ' \
+          '(pre_install and post_install hooks)')
+      end
+    end
+
+    describe 'Verbose List' do
+
+      before do
+        verbose_args = CLAide::ARGV.new(['--verbose'])
+        @command = Pod::Command::Plugins::Installed.new verbose_args
+      end
+
+      it 'no hooks' do
+        stub_plugins('cocoapods-foo1' => nil, 'cocoapods-foo2' => nil)
+
+        @command.run
+
+        UI.output.should.include <<FOO1
+cocoapods-foo1\e[0m
+    - Version:  2.0.1
+    - Homepage: https://github.com/proper-man/cocoapods-foo1
+    - Summary:  Gem Summary 1
+FOO1
+        UI.output.should.include <<FOO2
+cocoapods-foo2\e[0m
+    - Version:  2.0.2
+    - Homepage: https://github.com/proper-man/cocoapods-foo2
+FOO2
+      end
+
+      it 'one hook' do
+        stub_plugins(
+          'cocoapods-foo1' => :pre_install,
+          'cocoapods-foo2' => :post_install,
+        )
+
+        @command.run
+        UI.output.should.include <<FOO1
+cocoapods-foo1\e[0m
+    - Version:  2.0.1
+    - Hooks:
+      - pre_install
+    - Homepage: https://github.com/proper-man/cocoapods-foo1
+    - Summary:  Gem Summary 1
+FOO1
+        UI.output.should.include <<FOO2
+cocoapods-foo2\e[0m
+    - Version:  2.0.2
+    - Hooks:
+      - post_install
+    - Homepage: https://github.com/proper-man/cocoapods-foo2
+FOO2
+      end
+
+      it 'two hooks' do
+        stub_plugins('cocoapods-foo1' => [:pre_install, :post_install])
+
+        @command.run
+        UI.output.should.include <<FOO1
+cocoapods-foo1\e[0m
+    - Version:  2.0.1
+    - Hooks:
+      - pre_install
+      - post_install
+    - Homepage: https://github.com/proper-man/cocoapods-foo1
+    - Summary:  Gem Summary 1
+FOO1
+      end
+    end
+  end
+end

--- a/spec/command/plugins/installed_spec.rb
+++ b/spec/command/plugins/installed_spec.rb
@@ -27,7 +27,6 @@ module Pod
 
     before do
       UI.output = ''
-      Pod::HooksManager.registrations
     end
 
     it 'registers itself' do


### PR DESCRIPTION
For example if `cocoapods-keys` is installed

```
$ bundle exec pod plugins installed

Installed CocoaPods Plugins:
    - cocoapods-keys    : 1.0.0 (post_install hook)
    - cocoapods-try     : 0.4.3
    - cocoapods-trunk   : 0.5.0
    - cocoapods-plugins : 0.4.0
```

```
$ bundle exec pod plugins installed --verbose

Installed CocoaPods Plugins:

cocoapods-keys
    - Version:  1.0.0
    - Hooks:
      - post_install
    - Homepage: https://github.com/cocoapods/cocoapods-keys
    - Summary:  CocoaPods Keys will store sensitive data in your Mac's keychain. Then on running
    pod install they will be installed into your app's source code via the Pods library.

cocoapods-try
    - Version:  0.4.3
    - Homepage: https://github.com/cocoapods/cocoapods-try
    - Summary:  CocoaPods plugin which allows to quickly try the demo project of a Pod.

cocoapods-trunk
    - Version:  0.5.0
    - Summary:  Interact with trunk.cocoapods.org

cocoapods-plugins
    - Version:  0.4.0
    - Homepage: https://github.com/cocoapods/cocoapods-plugins
    - Summary:  CocoaPods plugin which shows info about available CocoaPods plugins.
```
_(Note: to test this you need to add `cocoapods-keys`'s `master` to your `Gemfile`, as the official `0.9.5` gem does not yet register the associated plugin name — only `master` does it properly)_

/cc @orta 
