### PR TITLE
added cocoapods-blacklist to plugins.json

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -175,6 +175,13 @@
       "author": "Pablo Bendersky",
       "url": "https://github.com/quadion/cocoapods-thumbs",
       "description": "Use cocoapods-thumbs to check upvotes or downvotes of Podspecs from your peers based on past experiences."
+    },
+    {
+      "gem": "cocoapods-blacklist",
+      "name": "CocoaPods Blacklist",
+      "author": "David Grandinetti",
+      "url": "https://github.com/yahoo/cocoapods-blacklist",
+      "description": "Check if a project is using a banned version of a pod. Handy for security audits."
     }
   ]
 }


### PR DESCRIPTION
Added http://github.com/yahoo/cocoapods-blacklist

A plugin to check a lock file for specific versions of pods that you should probably not deploy. I made it for our security group as a way to notify us about new vulnerabilities by failing our CI builds.

