### PR TITLE
Adds entry for cocoapods-mix-frameworks

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -261,6 +261,13 @@
       "author": "supern_lee",
       "url": "https://github.com/alibaba/cocoapods-uploader",
       "description": "Upload file/dir to remote storage."
+    },
+    {
+      "gem": "cocoapods-mix-frameworks",
+      "name": "CocoaPods Mix Frameworks",
+      "author": "Florent Vilmart",
+      "url": "https://github.com/flovilmart/cocoapods-mix-frameworks",
+      "description": "Mix use_framework! targets with static targets through a surrogate Framework target."
     }
   ]
 }


### PR DESCRIPTION
Cocoapods mix-frameworks let a project leverage both static and dynamic dependencies. Dynamic dependencies should be specified against an surrogate framework target, itself a target dependency.

The plugin removes sanity checks that would normally prevent that functional behaviour for App targets (not extensions etc...)