### PR TITLE
Add cocoapods-user-defined-build-types

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -288,6 +288,13 @@
       "author": "Siddharth Gupta",
       "url": "https://github.com/grab/cocoapods-pod-merge",
       "description": "Merge pods used by your iOS project, reducing the number of dynamic frameworks your app has to load on startup"
+    },
+    {
+      "gem": "cocoapods-user-defined-build-types",
+      "name": "CocoaPods User Defined Build Types",
+      "author": "Jonathan Cardasis",
+      "url": "https://github.com/joncardasis/cocoapods-user-defined-build-types",
+      "description": "A CocoaPods plugin which can selectively set build type per pod (static library, dynamic framework, etc.)"
     }
   ]
 }


### PR DESCRIPTION
Add `cocoapods-user-defined-build-types` to `package.json`.

Based on [this issue](https://github.com/CocoaPods/cocoapods-plugins/issues/105), it was preferred to open a PR.