### PR TITLE
Add cocoapods-s3-download

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -295,6 +295,13 @@
       "author": "Jonathan Cardasis",
       "url": "https://github.com/joncardasis/cocoapods-user-defined-build-types",
       "description": "A CocoaPods plugin which can selectively set build type per pod (static library, dynamic framework, etc.)"
+    },
+    {
+      "gem": "cocoapods-s3-download",
+      "name": "CocoaPods source from AWS S3",
+      "author": "Samuel Abreu",
+      "url": "https://github.com/samuelabreu/cocoapods-s3-download",
+      "description": "A CocoaPods plugin to download sources from AWS S3 using pre signed urls"
     }
   ]
 }


### PR DESCRIPTION
A plugin to enable CocoaPods use AWS S3 urls on spec.source, using presigned URLS to authenticate using AWS IAM