### PR TITLE
Add cocoapods-pod-linkage

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -323,6 +323,13 @@
       "author": "Microsoft Corporation",
       "url": "https://github.com/microsoft/cocoapods-azure-universal-packages",
       "description": "Enables CocoaPods to download Universal Packages from Azure Artifacts feeds."
+    },
+    {
+      "gem": "cocoapods-pod-linkage",
+      "name": "Pod Linkage",
+      "author": "Microsoft Corporation",
+      "url": "https://github.com/microsoft/cocoapods-pod-linkage",
+      "description": "A CocoaPods plugin for configuring the linkage type of a specific pod."
     }
   ]
 }


### PR DESCRIPTION
Adds support for the `:linkage` option to `pod` so you can mix static and dynamic linking in a single target.

For example:
```Ruby
target :MyTarget do
  use_frameworks! :linkage => :static

  pod 'MyStaticPod', '1.2.3'
  pod 'MyDynamicPod', '1.2.3', :linkage => :dynamic
end
```